### PR TITLE
hotfix: fix critical HTML rendering issue in desktop terminal

### DIFF
--- a/src/js/TerminalPortfolio.js
+++ b/src/js/TerminalPortfolio.js
@@ -232,7 +232,7 @@ export class TerminalPortfolio {
 
 <span class="output-text">Digite o número da opção ou o comando correspondente.</span>
 <span class="warning">💡 Dica: Digite '<span class="success">help</span>' para ver todos os comandos disponíveis!</span>`;
-    this.terminal.addToOutput(menuText);
+    this.terminal.addToOutput(menuText, 'system');
   }
 
   showProjects() {
@@ -244,7 +244,7 @@ export class TerminalPortfolio {
 </span>
 
 <div class="project-item">
-<span class="project-title">� Terminal Portfolio</span>
+<span class="project-title">📱 Terminal Portfolio</span>
 <span class="project-description">
 Portfólio interativo dual com interface terminal para desktop e BIOS Android para mobile.
 • <strong>Frontend:</strong> HTML5, CSS3, JavaScript ES6+ vanilla
@@ -323,7 +323,7 @@ Pipeline de microserviços com RabbitMQ para processamento transacional.
 <span class="output-text">🔄 Projetos em desenvolvimento ativo</span>
 <span class="output-text">📊 Demonstração de diferentes tecnologias</span>
 <span class="output-text">🔒 Aplicação de padrões de segurança</span>`;
-    this.terminal.addToOutput(projectsText);
+    this.terminal.addToOutput(projectsText, 'system');
   }
 
   // Expose methods for global access

--- a/src/js/commands/AdditionalCommands.js
+++ b/src/js/commands/AdditionalCommands.js
@@ -63,7 +63,7 @@ export class AdditionalCommands {
 </div>
 
 <span class="warning">🎯 Foco atual:</span> Arquitetura de microserviços e performance optimization`;
-    this.terminal.addToOutput(skillsText);
+    this.terminal.addToOutput(skillsText, 'system');
   }
 
   showExperience() {
@@ -108,7 +108,7 @@ export class AdditionalCommands {
 </div>
 
 <span class="success">📈 Crescimento contínuo:</span> 3+ anos de experiência hands-on em desenvolvimento`;
-    this.terminal.addToOutput(experienceText);
+    this.terminal.addToOutput(experienceText, 'system');
   }
 
   showEducation() {
@@ -154,7 +154,7 @@ planejamento estratégico de tecnologia
 </div>
 
 <span class="success">🏆 Status:</span> Sempre estudando - aprendizado contínuo é essencial!`;
-    this.terminal.addToOutput(educationText);
+    this.terminal.addToOutput(educationText, 'system');
   }
 
   showCertifications() {
@@ -222,7 +222,7 @@ planejamento estratégico de tecnologia
 • Oracle Java SE 17 Developer (em preparação)
 
 <span class="success">🎯 Meta:</span> Certificações são ferramentas, experiência prática é o que conta!`;
-    this.terminal.addToOutput(certificationsText);
+    this.terminal.addToOutput(certificationsText, 'system');
   }
 
   downloadResume() {
@@ -258,7 +258,7 @@ planejamento estratégico de tecnologia
 <span class="output-text">• Informações de contato atualizadas</span>
 
 <span class="warning">💡 Dica:</span> Para recrutadores e oportunidades profissionais, prefiro contato via LinkedIn.`;
-    this.terminal.addToOutput(resumeText);
+    this.terminal.addToOutput(resumeText, 'system');
   }
 
   showStatus() {
@@ -302,7 +302,7 @@ planejamento estratégico de tecnologia
 <span class="output-text">🌄 Fins de semana: 9h - 17h (projetos especiais)</span>
 
 <span class="success">💬 Entre em contato:</span> Sempre aberto para conversar sobre oportunidades interessantes!`;
-    this.terminal.addToOutput(statusText);
+    this.terminal.addToOutput(statusText, 'system');
   }
 
   sudoCommand() {
@@ -324,7 +324,7 @@ planejamento estratégico de tecnologia
     ║  🔐 Acesso root negado... por ora 😉  ║
     ╚══════════════════════════════════════╝
 </span>`;
-    this.terminal.addToOutput(sudoText);
+    this.terminal.addToOutput(sudoText, 'system');
   }
 
   coffeeCommand() {
@@ -370,7 +370,7 @@ planejamento estratégico de tecnologia
 <span class="output-text">• Tipo preferido: Espresso forte ☕💪</span>
 
 <span class="success">💡 Fun fact:</span> Este terminal foi desenvolvido após várias xícaras de café! ☕✨`;
-    this.terminal.addToOutput(coffeeText);
+    this.terminal.addToOutput(coffeeText, 'system');
   }
 
   hackerMode() {
@@ -412,7 +412,7 @@ planejamento estratégico de tecnologia
 <span class="error">WARNING: This is just for fun! 😄</span>
 <span class="output-text">Digite 'theme dark' para voltar ao normal.</span>`;
 
-    this.terminal.addToOutput(hackerText);
+    this.terminal.addToOutput(hackerText, 'system');
 
     // Remove hacker mode after 10 seconds
     setTimeout(() => {
@@ -453,7 +453,7 @@ planejamento estratégico de tecnologia
 <span class="output-text">You've been exploring too long.</span>
 <span class="output-text">Type 'exit' if you can... 😈</span>`;
 
-    this.terminal.addToOutput(matrixText);
+    this.terminal.addToOutput(matrixText, 'system');
   }
 
   konamiCode() {
@@ -480,7 +480,7 @@ planejamento estratégico de tecnologia
 
 <span class="success">🎊 Parabéns! Você encontrou o easter egg clássico!</span>`;
 
-    this.terminal.addToOutput(konamiText);
+    this.terminal.addToOutput(konamiText, 'system');
   }
 
   glitchEffect() {
@@ -512,7 +512,7 @@ planejamento estratégico de tecnologia
 <span class="highlight">🔧 HOTFIX APPLIED:</span>
 <span class="output-text">Glitch transformed into feature ✨</span>`;
 
-    this.terminal.addToOutput(glitchText);
+    this.terminal.addToOutput(glitchText, 'system');
 
     // Remove glitch effect after 5 seconds
     setTimeout(() => {
@@ -552,7 +552,7 @@ planejamento estratégico de tecnologia
 <span class="output-text">• Inspiração: Retro computing vibes</span>
 <span class="output-text">• Feito com: Muito café e dedicação ☕</span>`;
 
-    this.terminal.addToOutput(asciiText);
+    this.terminal.addToOutput(asciiText, 'system');
   }
 
   showGrowthfolio() {
@@ -611,7 +611,7 @@ Conjunto de microserviços reutilizáveis
 <span class="output-text">Democratizar o acesso a ferramentas de qualidade e acelerar</span>
 <span class="output-text">o crescimento profissional de desenvolvedores em todo o mundo.</span>`;
 
-    this.terminal.addToOutput(growthfolioText);
+    this.terminal.addToOutput(growthfolioText, 'system');
   }
 
   showEasterEggs() {
@@ -676,6 +676,6 @@ Conjunto de microserviços reutilizáveis
 <span class="output-text">Há alguns comandos escondidos que não estão na lista do 'help'...</span>
 <span class="output-text">Continue explorando! 🕵️‍♂️</span>`;
 
-    this.terminal.addToOutput(easterEggsText);
+    this.terminal.addToOutput(easterEggsText, 'system');
   }
 }

--- a/src/js/commands/BasicCommands.js
+++ b/src/js/commands/BasicCommands.js
@@ -10,14 +10,14 @@ export class BasicCommands {
 
   getCommands() {
     return {
-      help: () => this.terminal.addToOutput(CONTENT.help),
+      help: () => this.terminal.addToOutput(CONTENT.help, 'system'),
       clear: () => this.terminal.clearTerminal(),
-      about: () => this.terminal.addToOutput(CONTENT.about),
-      sobre: () => this.terminal.addToOutput(CONTENT.about),
-      1: () => this.terminal.addToOutput(CONTENT.about),
-      contact: () => this.terminal.addToOutput(CONTENT.contact),
-      contato: () => this.terminal.addToOutput(CONTENT.contact),
-      3: () => this.terminal.addToOutput(CONTENT.contact),
+      about: () => this.terminal.addToOutput(CONTENT.about, 'system'),
+      sobre: () => this.terminal.addToOutput(CONTENT.about, 'system'),
+      1: () => this.terminal.addToOutput(CONTENT.about, 'system'),
+      contact: () => this.terminal.addToOutput(CONTENT.contact, 'system'),
+      contato: () => this.terminal.addToOutput(CONTENT.contact, 'system'),
+      3: () => this.terminal.addToOutput(CONTENT.contact, 'system'),
       date: () => this.showDate(),
       pwd: () => this.showPath(),
       ls: () => this.listFiles(),
@@ -41,12 +41,12 @@ export class BasicCommands {
       minute: "2-digit",
       second: "2-digit",
     });
-    this.terminal.addToOutput(`<span class="output-text">📅 ${dateStr}</span>`);
+    this.terminal.addToOutput(`<span class="output-text">📅 ${dateStr}</span>`, 'system');
   }
 
   showPath() {
     this.terminal.addToOutput(
-      '<span class="output-text">📁 /home/felipe/portfolio</span>'
+      '<span class="output-text">📁 /home/felipe/portfolio</span>', 'system'
     );
   }
 
@@ -55,7 +55,7 @@ export class BasicCommands {
 <span class="output-text">📁 Arquivos no diretório atual:</span>
 <span class="success">📄 about.txt</span>      <span class="success">📝 projects.md</span>     <span class="success">📋 contact.json</span>
 <span class="success">📄 resume.pdf</span>     <span class="success">⚙️ skills.yml</span>      <span class="success">💻 portfolio.js</span>`;
-    this.terminal.addToOutput(files);
+    this.terminal.addToOutput(files, 'system');
   }
 
   listFilesDetailed() {
@@ -67,7 +67,7 @@ export class BasicCommands {
 <span class="success">-rw-r--r--</span> 1 felipe felipe  4096 Jul 29 10:33 <span class="success">📄 resume.pdf</span>
 <span class="success">-rw-r--r--</span> 1 felipe felipe   256 Jul 29 10:34 <span class="success">⚙️ skills.yml</span>
 <span class="success">-rwxr-xr-x</span> 1 felipe felipe  8192 Jul 29 10:35 <span class="success">💻 portfolio.js</span>`;
-    this.terminal.addToOutput(detailedFiles);
+    this.terminal.addToOutput(detailedFiles, 'system');
   }
 
   whoami() {
@@ -86,6 +86,6 @@ export class BasicCommands {
 <span class="warning">💬 Stack preferido:</span> Go pra performance. Java pra manter vivo.
 
 <span class="info">💡 Dica:</span> Digite <code>contributions</code> para ver minha atividade no GitHub`;
-    this.terminal.addToOutput(introText);
+    this.terminal.addToOutput(introText, 'system');
   }
 }

--- a/src/js/commands/ContributionCommands.js
+++ b/src/js/commands/ContributionCommands.js
@@ -22,7 +22,7 @@ class ContributionCommands {
   </div>
 </div>`;
 
-    this.terminal.addToOutput(output);
+    this.terminal.addToOutput(output, 'system');
 
     // Initialize widget
     setTimeout(() => {
@@ -141,11 +141,11 @@ class ContributionCommands {
   <p class="command-tip">💡 Use <code>contributions --enhanced</code> para análise completa</p>
 </div>`;
 
-      this.terminal.addOutput(output);
+      this.terminal.addToOutput(output, 'system');
       return true;
       
     } catch (error) {
-      this.terminal.addOutput(`<span class="error">Erro ao carregar estatísticas: ${error.message}</span>`);
+      this.terminal.addToOutput(`<span class="error">Erro ao carregar estatísticas: ${error.message}</span>`, 'system');
       return false;
     }
   }

--- a/src/js/core/CommandProcessor.js
+++ b/src/js/core/CommandProcessor.js
@@ -20,7 +20,7 @@ export class CommandProcessor {
     if (command === "") return;
 
     this.terminal.addToOutput(
-      `<span class="prompt">felipe-macedo@portfolio:~$ </span><span class="command">${input}</span>`
+      `<span class="prompt">felipe-macedo@portfolio:~$ </span><span class="command">${input}</span>`, 'system'
     );
 
     this.executeCommand(command);
@@ -37,10 +37,10 @@ export class CommandProcessor {
     } else {
       this.terminal.showInvalidCommandFeedback();
       this.terminal.addToOutput(
-        `<span class="error">❌ bash: ${command}: comando não encontrado</span>`
+        `<span class="error">❌ bash: ${command}: comando não encontrado</span>`, 'system'
       );
       this.terminal.addToOutput(
-        `<span class="output-text">💡 Digite '<span class='success'>help</span>' para ver os comandos disponíveis.</span>`
+        `<span class="output-text">💡 Digite '<span class='success'>help</span>' para ver os comandos disponíveis.</span>`, 'system'
       );
     }
   }

--- a/src/js/features/ThemeManager.js
+++ b/src/js/features/ThemeManager.js
@@ -32,7 +32,7 @@ export class ThemeManager {
     this.terminal.addToOutput(
       `<span class="success">🎨 Tema alterado para: ${
         themes[theme] || theme
-      }</span>`
+      }</span>`, 'system'
     );
 
     document.body.style.transition = "all 0.3s ease";


### PR DESCRIPTION
- Fix HTML tags being displayed as text instead of rendered
- Add 'system' type parameter to all addToOutput calls with HTML content
- Affected files: TerminalPortfolio.js, BasicCommands.js, AdditionalCommands.js
- Affected files: CommandProcessor.js, ThemeManager.js, ContributionCommands.js
- Terminal now properly renders HTML formatting and styles
- Resolves issue where commands showed raw HTML tags in output